### PR TITLE
Add transitioning for PR events

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,9 +17,11 @@ async function run() {
         addReleaseInfo
       );
     } else if (eventName === "pull_request") {
-      const { title } = payload.pull_request;
+      const { title, body } = payload.pull_request;
+      const { ref } = payload.pull_request.head;
+      const content = `${title} ${body} ${ref}`;
       updatedStories = await ch.transitionStories(
-        title,
+        content,
         core.getInput('endStateName')
       );
     } else {

--- a/index.js
+++ b/index.js
@@ -5,9 +5,10 @@ const ch = require('./src/clubhouse');
 
 async function run() {
   try {
+    const { payload, eventName } = github.context;
     let updatedStories;
-    if (github.context.eventName === "release") {
-      const { body, html_url } = github.context.payload.release;
+    if (eventName === "release") {
+      const { body, html_url } = payload.release;
       const addReleaseInfo = (core.getInput('addReleaseInfo') === 'true');
       updatedStories = await ch.releaseStories(
         body,
@@ -15,8 +16,8 @@ async function run() {
         html_url,
         addReleaseInfo
       );
-    } else if (github.context.eventName === "pull_request") {
-      const { title } = github.context.payload.pull_request;
+    } else if (eventName === "pull_request") {
+      const { title } = payload.pull_request;
       updatedStories = await ch.transitionStories(
         title,
         core.getInput('endStateName')

--- a/index.js
+++ b/index.js
@@ -5,16 +5,27 @@ const ch = require('./src/clubhouse');
 
 async function run() {
   try {
-    const { body, html_url } = github.context.payload.release;
-    const addReleaseInfo = (core.getInput('addReleaseInfo') === 'true');
-    const releasedStories = await ch.releaseStories(
-      body,
-      core.getInput('endStateName'),
-      html_url,
-      addReleaseInfo
-    );
-    core.setOutput(releasedStories);
-    console.log(`Updated Stories: \n \n${releasedStories.join(' \n')}`);
+    let updatedStories;
+    if (github.context.eventName === "release") {
+      const { body, html_url } = github.context.payload.release;
+      const addReleaseInfo = (core.getInput('addReleaseInfo') === 'true');
+      updatedStories = await ch.releaseStories(
+        body,
+        core.getInput('endStateName'),
+        html_url,
+        addReleaseInfo
+      );
+    } else if (github.context.eventName === "pull_request") {
+      const { title } = github.context.payload.pull_request;
+      updatedStories = await ch.transitionStories(
+        title,
+        core.getInput('endStateName')
+      );
+    } else {
+      throw new Error("Invalid event type");
+    }
+    core.setOutput(updatedStories);
+    console.log(`Updated Stories: \n \n${updatedStories.join(' \n')}`);
   }
   catch (error) {
     core.setFailed(error.message);

--- a/src/clubhouse.js
+++ b/src/clubhouse.js
@@ -4,15 +4,17 @@ const clubhouseToken = process.env.INPUT_CLUBHOUSETOKEN;
 const client = Clubhouse.create(clubhouseToken);
 
 /**
- * Finds all clubhouse story IDs in body of release object.
+ * Finds all clubhouse story IDs in some string content.
  *
- * @param {string} releaseBody - The body field of a github release object.
+ * @param {string} content - content that may contain story IDs.
  * @return {Array} - Clubhouse story IDs 1-7 digit strings.
  */
 
-function extractStoryIds(releaseBody) {
+function extractStoryIds(content) {
     const regex = /(?<=ch)\d{1,7}/g;
-    return releaseBody.match(regex);
+    const all = content.match(regex);
+    const unique = [...new Set(all)];
+    return unique;
 }
 
 /**
@@ -232,9 +234,9 @@ async function transitionStories(
     endStateName
 ) {
     const storyIds = extractStoryIds(content);
-    if (storyIds === null) {
+    if (storyIds.length === 0) {
         console.warn('No clubhouse stories were found.');
-        return [];
+        return storyIds;
     }
     const stories = await addDetailstoStories(storyIds);
     const workflows = await client.listWorkflows();

--- a/src/clubhouse.js
+++ b/src/clubhouse.js
@@ -203,7 +203,7 @@ async function releaseStories(
         console.warn('No clubhouse stories were found in the release.');
         return [];
     }
-    const stories = await addDetailstoStories(storyIds, releaseUrl);
+    const stories = await addDetailstoStories(storyIds);
     const storiesWithUpdatedDescriptions = updateDescriptionsMaybe(
         stories,
         releaseUrl,
@@ -212,6 +212,34 @@ async function releaseStories(
     const workflows = await client.listWorkflows();
     const storiesWithEndStateIds = addEndStateIds(
         storiesWithUpdatedDescriptions,
+        workflows,
+        endStateName
+    );
+    const updatedStoryNames = await updateStories(storiesWithEndStateIds);
+    return updatedStoryNames;
+}
+
+/**
+ * Updates all clubhouse stories found in given content.
+ *
+ * @param {string} content - a string that might have clubhouse story IDs.
+ * @param {string} endStateName - Desired workflow state for stories.
+ * @return {Promise<Array>} - Names of the stories that were updated
+ */
+
+async function transitionStories(
+    content,
+    endStateName
+) {
+    const storyIds = extractStoryIds(content);
+    if (storyIds === null) {
+        console.warn('No clubhouse stories were found.');
+        return [];
+    }
+    const stories = await addDetailstoStories(storyIds);
+    const workflows = await client.listWorkflows();
+    const storiesWithEndStateIds = addEndStateIds(
+        stories,
         workflows,
         endStateName
     );
@@ -230,5 +258,6 @@ module.exports = {
     addEndStateIds,
     updateStory,
     updateStories,
-    releaseStories
+    releaseStories,
+    transitionStories
 };

--- a/test/clubhouse.test.js
+++ b/test/clubhouse.test.js
@@ -31,6 +31,8 @@ other bugch015
     const release2 = '7895 [94536] (98453) #89';
     const release3 = 'tchotchke ch-thing chi789';
     const prTitle = 'Re-writing the app in another language [ch1919]';
+    const branch = 'user/ch2189/something-important-maybe';
+    const duplicates = 'Only one change [ch6754] ch6754 [ch6754]';
     const releaseUrl = 'https://github.com/org/repo/releases/14';
     const stories = [
         {
@@ -111,9 +113,11 @@ other bugch015
     describe('story id extraction from release body', function () {
         const expectedIds0 = ['0002', '1', '12345', '987', '56789'];
         const expectedIds1 = ['4287', '890', '8576', '3', '015'];
-        const expectedIds2 = null;
-        const expectedIds3 = null;
+        const expectedIds2 = [];
+        const expectedIds3 = [];
         const expectedIdsPR = ['1919'];
+        const expectedIdsBranch = ['2189'];
+        const expectedIdsDups = ['6754'];
 
         it('should find all story ids in well formatted release', function () {
             const storyIds = ch.extractStoryIds(release0);
@@ -127,17 +131,27 @@ other bugch015
 
         it('should not match plain number strings', function () {
             const storyIds = ch.extractStoryIds(release2);
-            assert.strictEqual(storyIds, expectedIds2);
+            assert.deepStrictEqual(storyIds, expectedIds2);
         });
 
         it('should not match other strings beginning in "ch"', function () {
             const storyIds = ch.extractStoryIds(release3);
-            assert.strictEqual(storyIds, expectedIds3);
+            assert.deepStrictEqual(storyIds, expectedIds3);
         });
 
         it('should find 1 story id in PR Title', function () {
             const storyIds = ch.extractStoryIds(prTitle);
             assert.deepStrictEqual(storyIds, expectedIdsPR);
+        });
+
+        it('should find 1 story id in branch name', function () {
+            const storyIds = ch.extractStoryIds(branch);
+            assert.deepStrictEqual(storyIds, expectedIdsBranch);
+        });
+
+        it('should find 1 story id from duplicates', function () {
+            const storyIds = ch.extractStoryIds(duplicates);
+            assert.deepStrictEqual(storyIds, expectedIdsDups);
         });
     });
 

--- a/test/clubhouse.test.js
+++ b/test/clubhouse.test.js
@@ -30,6 +30,7 @@ other bugch015
 `;
     const release2 = '7895 [94536] (98453) #89';
     const release3 = 'tchotchke ch-thing chi789';
+    const prTitle = 'Re-writing the app in another language [ch1919]';
     const releaseUrl = 'https://github.com/org/repo/releases/14';
     const stories = [
         {
@@ -112,15 +113,16 @@ other bugch015
         const expectedIds1 = ['4287', '890', '8576', '3', '015'];
         const expectedIds2 = null;
         const expectedIds3 = null;
+        const expectedIdsPR = ['1919'];
 
         it('should find all story ids in well formatted release', function () {
             const storyIds = ch.extractStoryIds(release0);
-            assert.deepEqual(storyIds, expectedIds0);
+            assert.deepStrictEqual(storyIds, expectedIds0);
         });
 
         it('should find all story ids in poorly formatted release', function () {
             const storyIds = ch.extractStoryIds(release1);
-            assert.deepEqual(storyIds, expectedIds1);
+            assert.deepStrictEqual(storyIds, expectedIds1);
         });
 
         it('should not match plain number strings', function () {
@@ -131,6 +133,11 @@ other bugch015
         it('should not match other strings beginning in "ch"', function () {
             const storyIds = ch.extractStoryIds(release3);
             assert.strictEqual(storyIds, expectedIds3);
+        });
+
+        it('should find 1 story id in PR Title', function () {
+            const storyIds = ch.extractStoryIds(prTitle);
+            assert.deepStrictEqual(storyIds, expectedIdsPR);
         });
     });
 
@@ -220,7 +227,7 @@ https://github.com/org/repo/releases/14
                 releaseUrl,
                 false
             );
-            assert.deepEqual(stories, newStories);
+            assert.deepStrictEqual(stories, newStories);
         });
     });
 


### PR DESCRIPTION
### Context

It's been requested to transition stories in response to certain `pull_request` events.

### Analysis

All of the basic pieces already exist to do this. Its a slightly different/smaller number of steps to just transition a story, so at least for now, can live with a bit of duplication and simply split all non-release-cases to a diff entrypoint to the clubhouse module.

### Solution

- Added `transitionStories` to handle non-releases
- Updated the action's `run` entrypoint  to conditionally invoke `ch` depending on the event
- Added test for extracting story ID from PR Title
- Updated README
- Repackaged

### Testing

Ran on the testing repo:
https://github.com/farmersdog/clubhouse-action-test/pull/1/checks?check_run_id=814832485