### PR TITLE
Little bit more flexible matching for story ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ jobs:
           addReleaseInfo: false
 ```
 
-The only requirement for identifying stories in a release is that the id is prepended with `ch`. Any surrounding brackets, or no brackets, will all work.
+The only requirement for identifying stories in a release is that the id is prepended with `ch` or `ch-`. Any capitalization, surrounding brackets, or no brackets, will all work.
 
 For example, if the below block is the release body the first three will be extracted, and the last one will not.
 
@@ -47,11 +47,11 @@ For example, if the below block is the release body the first three will be extr
 ### Features
 
 ch1234 Shiny New Thing
-[ch9876] Bug In Disguise
+[ch-9876] Bug In Disguise
 
 ### Bugs
 
-(ch5432) Some color was off
+(CH5432) Some color was off
 [1928]  Lost $$$$
 ```
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -1425,6 +1425,32 @@ Response.prototype.clone = function() {
 
 /***/ }),
 
+/***/ 82:
+/***/ (function(__unusedmodule, exports) {
+
+"use strict";
+
+// We use any as a valid input type
+/* eslint-disable @typescript-eslint/no-explicit-any */
+Object.defineProperty(exports, "__esModule", { value: true });
+/**
+ * Sanitizes an input into a string so it can be passed into issueCommand safely
+ * @param input input to sanitize into a string
+ */
+function toCommandValue(input) {
+    if (input === null || input === undefined) {
+        return '';
+    }
+    else if (typeof input === 'string' || input instanceof String) {
+        return input;
+    }
+    return JSON.stringify(input);
+}
+exports.toCommandValue = toCommandValue;
+//# sourceMappingURL=utils.js.map
+
+/***/ }),
+
 /***/ 87:
 /***/ (function(module) {
 
@@ -1613,6 +1639,42 @@ module.exports = {
     'xxbig5': 'big5hkscs',
 };
 
+
+/***/ }),
+
+/***/ 102:
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+// For internal use, subject to change.
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+    result["default"] = mod;
+    return result;
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+// We use any as a valid input type
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const fs = __importStar(__webpack_require__(747));
+const os = __importStar(__webpack_require__(87));
+const utils_1 = __webpack_require__(82);
+function issueCommand(command, message) {
+    const filePath = process.env[`GITHUB_${command}`];
+    if (!filePath) {
+        throw new Error(`Unable to find environment variable for file command ${command}`);
+    }
+    if (!fs.existsSync(filePath)) {
+        throw new Error(`Missing file at path: ${filePath}`);
+    }
+    fs.appendFileSync(filePath, `${utils_1.toCommandValue(message)}${os.EOL}`, {
+        encoding: 'utf8'
+    });
+}
+exports.issueCommand = issueCommand;
+//# sourceMappingURL=file-command.js.map
 
 /***/ }),
 
@@ -6499,6 +6561,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const os = __importStar(__webpack_require__(87));
+const utils_1 = __webpack_require__(82);
 /**
  * Commands
  *
@@ -6552,28 +6615,14 @@ class Command {
         return cmdStr;
     }
 }
-/**
- * Sanitizes an input into a string so it can be passed into issueCommand safely
- * @param input input to sanitize into a string
- */
-function toCommandValue(input) {
-    if (input === null || input === undefined) {
-        return '';
-    }
-    else if (typeof input === 'string' || input instanceof String) {
-        return input;
-    }
-    return JSON.stringify(input);
-}
-exports.toCommandValue = toCommandValue;
 function escapeData(s) {
-    return toCommandValue(s)
+    return utils_1.toCommandValue(s)
         .replace(/%/g, '%25')
         .replace(/\r/g, '%0D')
         .replace(/\n/g, '%0A');
 }
 function escapeProperty(s) {
-    return toCommandValue(s)
+    return utils_1.toCommandValue(s)
         .replace(/%/g, '%25')
         .replace(/\r/g, '%0D')
         .replace(/\n/g, '%0A')
@@ -6957,6 +7006,8 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const command_1 = __webpack_require__(431);
+const file_command_1 = __webpack_require__(102);
+const utils_1 = __webpack_require__(82);
 const os = __importStar(__webpack_require__(87));
 const path = __importStar(__webpack_require__(622));
 /**
@@ -6983,9 +7034,17 @@ var ExitCode;
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function exportVariable(name, val) {
-    const convertedVal = command_1.toCommandValue(val);
+    const convertedVal = utils_1.toCommandValue(val);
     process.env[name] = convertedVal;
-    command_1.issueCommand('set-env', { name }, convertedVal);
+    const filePath = process.env['GITHUB_ENV'] || '';
+    if (filePath) {
+        const delimiter = '_GitHubActionsFileCommandDelimeter_';
+        const commandValue = `${name}<<${delimiter}${os.EOL}${convertedVal}${os.EOL}${delimiter}`;
+        file_command_1.issueCommand('ENV', commandValue);
+    }
+    else {
+        command_1.issueCommand('set-env', { name }, convertedVal);
+    }
 }
 exports.exportVariable = exportVariable;
 /**
@@ -7001,7 +7060,13 @@ exports.setSecret = setSecret;
  * @param inputPath
  */
 function addPath(inputPath) {
-    command_1.issueCommand('add-path', {}, inputPath);
+    const filePath = process.env['GITHUB_PATH'] || '';
+    if (filePath) {
+        file_command_1.issueCommand('PATH', inputPath);
+    }
+    else {
+        command_1.issueCommand('add-path', {}, inputPath);
+    }
     process.env['PATH'] = `${inputPath}${path.delimiter}${process.env['PATH']}`;
 }
 exports.addPath = addPath;
@@ -7301,7 +7366,7 @@ const client = Clubhouse.create(clubhouseToken);
  */
 
 function extractStoryIds(content) {
-    const regex = /(?<=ch)\d{1,7}/g;
+    const regex = /(?<=ch|ch-)\d{1,7}/gi;
     const all = content.match(regex);
     const unique = [...new Set(all)];
     return unique;

--- a/src/clubhouse.js
+++ b/src/clubhouse.js
@@ -11,7 +11,7 @@ const client = Clubhouse.create(clubhouseToken);
  */
 
 function extractStoryIds(content) {
-    const regex = /(?<=ch)\d{1,7}|(?<=ch-)\d{1,7}/gi;
+    const regex = /(?<=ch|ch-)\d{1,7}/gi;
     const all = content.match(regex);
     const unique = [...new Set(all)];
     return unique;

--- a/src/clubhouse.js
+++ b/src/clubhouse.js
@@ -11,7 +11,7 @@ const client = Clubhouse.create(clubhouseToken);
  */
 
 function extractStoryIds(content) {
-    const regex = /(?<=ch)\d{1,7}/g;
+    const regex = /(?<=ch)\d{1,7}|(?<=ch-)\d{1,7}/gi;
     const all = content.match(regex);
     const unique = [...new Set(all)];
     return unique;

--- a/test/clubhouse.test.js
+++ b/test/clubhouse.test.js
@@ -17,22 +17,28 @@ describe('clubhouse module', function() {
 [ch0002] feature 1
 [ch1] feature 2
 [ch12345] feature 3
+[ch-123456] feature 4
+[CH-42] feature 5
 
 ### Bugs
 [ch987] Bug 1
 [ch56789] Bug 2
+[ch-314] Bug 3
+[Ch2] Bug 4
 `;
     const release1 = `
 ch4287 found a bug(ch890) blah
 ch8576cool new stuff
 [ch3]other thing
 other bugch015
+someCH88foo
+Thisch-33th
 `;
     const release2 = '7895 [94536] (98453) #89';
-    const release3 = 'tchotchke ch-thing chi789';
+    const release3 = 'tchotchke ch-thing chi789 CZECHAIR CH-some2';
     const prTitle = 'Re-writing the app in another language [ch1919]';
     const branch = 'user/ch2189/something-important-maybe';
-    const duplicates = 'Only one change [ch6754] ch6754 [ch6754]';
+    const duplicates = 'Only one change [ch6754] CH6754 [ch-6754]';
     const releaseUrl = 'https://github.com/org/repo/releases/14';
     const stories = [
         {
@@ -111,8 +117,8 @@ other bugch015
         }
     ];
     describe('story id extraction from release body', function () {
-        const expectedIds0 = ['0002', '1', '12345', '987', '56789'];
-        const expectedIds1 = ['4287', '890', '8576', '3', '015'];
+        const expectedIds0 = ['0002', '1', '12345', '123456', '42', '987', '56789', '314', '2'];
+        const expectedIds1 = ['4287', '890', '8576', '3', '015', '88', '33'];
         const expectedIds2 = [];
         const expectedIds3 = [];
         const expectedIdsPR = ['1919'];


### PR DESCRIPTION
Thanks for creating this GitHub Action!

**Why this change?**
In [Clubhouse documentation](https://help.clubhouse.io/hc/en-us/articles/207540323-Using-Branches-and-Pull-Requests-with-the-Clubhouse-VCS-Integrations#work-with-pr) sometimes `[ch-xxx]` is referred to as a valid way to write a story ID to link it. Also [GitHub autolinking](https://docs.github.com/en/github/administering-a-repository/managing-repository-settings/configuring-autolinks-to-reference-external-resources) requires a minimum of 3 characters leading the number. Therefore I think it's good to be a little bit more flexible and also allow the `ch-` prefix.

In addition sometimes people capitalize the prefix, think it's good to be lenient in that case and also pick up the story. So this PR also fixes #8.

**Changes:**
- Case insensitive matching for the `ch` charactars
- Support for (optional) dash between `ch` and numbers
- Updated tests

**These are all valid story ids now:**
- ch123
- CH123
- cH123
- ch-123
- CH-123
- Ch123