### PR TITLE
dep(actions): update from Node12 to Node16

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -5,10 +5,10 @@ jobs:
   unit-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: '12'
+          node-version: '16'
       - run: yarn install --frozen-lockfile
       - run: yarn lint
       - run: yarn test

--- a/action.yml
+++ b/action.yml
@@ -19,5 +19,5 @@ outputs:
   updatedStories:
     description: An array of the story names that were updated
 runs:
-  using: node12
+  using: node16
   main: dist/index.js


### PR DESCRIPTION
Signed-off-by: Enes <ahmedenesturan@gmail.com>

The GitHub Actions workflow gives the following annotation while running the action:

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

We need to update Node version from 12 to 16 in the action config. 